### PR TITLE
chore(deps): bump react from 19.2.3 to 19.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "lucide-react": "^0.575.0",
-        "react": "^19.2.3",
+        "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.575.0",
-    "react": "^19.2.3",
+    "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bumps `react` from 19.2.3 to 19.2.4 to match `react-dom` at the same version
- Resolves the version mismatch that caused Dependabot PR #45 to fail CI (react 19.2.4 + react-dom 19.2.3)
- Replaces the closed PR #45

## Test plan

- [ ] CI build passes (react and react-dom both at 19.2.4, no version mismatch)

🤖 Generated with [Claude Code](https://claude.ai/code)